### PR TITLE
Remove import statement adjustment. Fix permission

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,13 +38,13 @@ RUN sudo cp /etc/apache2/mods-available/headers.load /etc/apache2/mods-enabled &
 COPY config/config.py /root/vatic/config.py
 
 # We need to adjust some of these guys's import statements...
-RUN sed  -i'' "s/import Image/from PIL import Image/" \
-    /usr/local/lib/python2.7/dist-packages/pyvision-0.3.1-py2.7-linux-x86_64.egg/vision/frameiterators.py \
-    /usr/local/lib/python2.7/dist-packages/pyvision-0.3.1-py2.7-linux-x86_64.egg/vision/ffmpeg.py \
-    /usr/local/lib/python2.7/dist-packages/pyvision-0.3.1-py2.7-linux-x86_64.egg/vision/visualize.py \
-    /root/vatic/models.py \
-    /root/vatic/cli.py \
-    /usr/local/lib/python2.7/dist-packages/pyvision-0.3.1-py2.7-linux-x86_64.egg/vision/pascal.py
+#RUN sed  -i'' "s/import Image/from PIL import Image/" \
+#    /usr/local/lib/python2.7/dist-packages/pyvision-0.3.1-py2.7-linux-x86_64.egg/vision/frameiterators.py \
+#    /usr/local/lib/python2.7/dist-packages/pyvision-0.3.1-py2.7-linux-x86_64.egg/vision/ffmpeg.py \
+#    /usr/local/lib/python2.7/dist-packages/pyvision-0.3.1-py2.7-linux-x86_64.egg/vision/visualize.py \
+#    /root/vatic/models.py \
+#    /root/vatic/cli.py \
+#    /usr/local/lib/python2.7/dist-packages/pyvision-0.3.1-py2.7-linux-x86_64.egg/vision/pascal.py
 
 RUN sudo /etc/init.d/mysql start && \
     cd /root/vatic && \
@@ -58,6 +58,10 @@ RUN sudo chown -R 755 /root/vatic/public && \
     apt-get install -y links && \
     apt-get install -y python-scipy && \
     sudo apache2ctl restart
+
+# Added the data folder, and making it accessible to www-data which is running the dumping code from the php codes.
+RUN mkdir /root/vatic/data && \
+    sudo chown -R www-data:www-data /root/vatic/data
 
 # Debug tools
 RUN apt-get install -y nano w3m man


### PR DESCRIPTION
Dependencies already using the correct PIL import statements in their current version. This adjustment only makes it erroneous.
When dumping as pascal, the os.link statement cannot be processed as the source folder is owned by root. Adjusting the data folder to be owned by www-data (account executing dump) should solve the issue.